### PR TITLE
Add Support for Server Groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # we don't want to include the source files of the dependencies
 vendor
+
+# IntelliJ
+.idea
+docker-machine-driver-cloudscale.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 before_deploy:
 - go get github.com/mitchellh/gox
 - mkdir releases
-- gox -os='!windows !netbsd !openbsd !darwin !freebsd' -osarch='!linux/mipsle !linux/arm !linux/s390x !linux/mips64le !linux/mips !linux/mips64'
+- gox -osarch="linux/amd64 darwin/amd64"
   -output="releases/{{.Dir}}_`git describe --tags --abbrev=0`_{{.OS}}_{{.Arch}}/{{.Dir}}"
   -ldflags "-X main.Version=`git describe --tags --abbrev=0`"
 - find releases -maxdepth 2 -mindepth 2 -type f -exec bash -c 'tar -cvzf "$(dirname

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: iNzUF8QKEW7W+W/Aogt7UiwiTXTyZ472R/oLR7RFE2flTSxd1BXR9ZV3k7RvedhN/brFc+cnUFohQtDsRj4VG4+rhxhAOCwJ1uzPwLTQXtd+Pq1TwVV7AHaDdLeSDcHzrVXkWNoNuju9AFN9t+w4SGA5swiA1hC9Sib4HZSsuU3XdvL25g6pK8bPxSyHFWtIKyeqshE+d8+RqNN+1c7zaHIJHaOKep7K3hl3QBmx4L2ibRfE7LMZk+GKioN5cVhn3JCf/t1dUKV87Uwd1AHubCxttQ1r2cVNQ0fdp2LkzPwiwiMkDOU+OHpjtB5HBS4TQgSlo7TXSIw5Pd14iwWfKC/J2qvO/xZ54Ofp0mMjDWvWWBDVJwNWTkmFDbCR1lJ0mNFjmfLfHIWjFH/LgNTPGZYMo87fLAtMoPITwj4M3yuq9DfrtX3zvrVwMHSoYL4eviHTkdksYbkgnouHLMW0HGFGA06BOuQrg9UsyX/j/TuejrmphgIM7TNPz8Sria4KZroLPUhRx6qlFQmKduf8NSZU8Iqtwq7VwmgZAk+WmGh2fAk+DQiw+kT33HTVIMOGPvz6C4aD63JXWIT0zZvh4js7hen9Hbn1r1qyoboBjlsoX9DUW1LnzQfN/Yoz2Q9E5Qemr09LReOzteUZd+rvqZkyaT0jZjhMSDF2BByDG28=
+    secure: $GITHUB_OAUTH_TOKEN
   file: "releases/*.tar.gz"
   file_glob: true # enables wildcards in file names
   skip_cleanup: true
+  prerelease: true
   on:
-    repo: splattner/docker-machine-driver-cloudscale
     tags: true

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,11 +14,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:023cea25b4b7df51b518d521495da46118c6289d3ed8ee875f518955fb8ade24"
-  name = "github.com/cloudscale-ch/cloudscale-go-sdk"
+  digest = "1:7e52523af9f20443cbc01f3c3f90b28073a4980325acec94fde0f399b6d67cc8"
+  name = "github.com/alakae/cloudscale-go-sdk"
   packages = ["."]
   pruneopts = "UT"
-  revision = "17fbddda00c87b73c5ceb601aeaced294748231b"
+  revision = "9c78af9971cfe72e69bcd6a6f8df9a6b646a6f0b"
 
 [[projects]]
   branch = "master"
@@ -145,7 +145,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/cloudscale-ch/cloudscale-go-sdk",
+    "github.com/alakae/cloudscale-go-sdk",
     "github.com/docker/machine/libmachine/drivers",
     "github.com/docker/machine/libmachine/drivers/plugin",
     "github.com/docker/machine/libmachine/log",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,11 +14,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7e52523af9f20443cbc01f3c3f90b28073a4980325acec94fde0f399b6d67cc8"
-  name = "github.com/alakae/cloudscale-go-sdk"
+  digest = "1:2e6f42fc7cd06ac773b148a6e0d0ffa5ab0d943a86babe7057190617eb656afa"
+  name = "github.com/cloudscale-ch/cloudscale-go-sdk"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9c78af9971cfe72e69bcd6a6f8df9a6b646a6f0b"
+  revision = "c0ff9b92e8ad337284ed2e341a65b835af9c3632"
 
 [[projects]]
   branch = "master"
@@ -145,7 +145,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/alakae/cloudscale-go-sdk",
+    "github.com/cloudscale-ch/cloudscale-go-sdk",
     "github.com/docker/machine/libmachine/drivers",
     "github.com/docker/machine/libmachine/drivers/plugin",
     "github.com/docker/machine/libmachine/log",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/cloudscale-ch/cloudscale-go-sdk"
+  name = "github.com/alakae/cloudscale-go-sdk"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/alakae/cloudscale-go-sdk"
+  name = "github.com/cloudscale-ch/cloudscale-go-sdk"
 
 [prune]
   go-tests = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,197 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
 MIT License
 
 Copyright (c) 2017-2018 Jonas Stoehr

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ CLOUDSCALE_TOKEN=... \
   && CLOUDSCALE_IMAGE=ubuntu-18.04 \
   && CLOUDSCALE_FLAVOR=flex-4
   && docker-machine create \
-     --driver hetzner \
+     --driver cloudscale \
      some-machine
 ```   
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ docker-machine create \
 - `--cloudscale-ssh-port`: The SSH Port (defaults to `22`)
 - `--cloudscale-use-private-network`: Enables the Private network Interface (defaults to `false`)
 - `--cloudscale-use-ipv6`: Enables IPv6 on Public Network Interface (defaults to `false`)
+- `--cloudscale-server-groups`: the UUIDs of server groups identifying the [server groups](https://www.cloudscale.ch/en/api/v1#server-groups) to which the new server will be added.
 - `--cloudscale-anti-affinity-with`: the UUID of another server to create an anti-affinity group with that server or add it to the same group as that server.
 
 

--- a/driver.go
+++ b/driver.go
@@ -29,6 +29,7 @@ type Driver struct {
 	UserDataFile      string
 	VolumeSizeGB      int
 	AntiAffinityWith  string
+	ServerGroups      []string
 }
 
 const (
@@ -101,6 +102,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "cloudscale-anti-affinity-with",
 			Usage:  "a UUID of another server",
 		},
+		mcnflag.StringSliceFlag{
+			EnvVar: "CLOUDSCALE_SERVER_GROUPS",
+			Name:   "cloudscale-server-groups",
+			Usage:  "a list of UUIDs of server groups",
+		},
 		mcnflag.BoolFlag{
 			EnvVar: "CLOUDSCALE_USE_IPV6",
 			Name:   "cloudscale-use-ipv6",
@@ -141,6 +147,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SSHPort = flags.Int("cloudscale-ssh-port")
 	d.VolumeSizeGB = flags.Int("cloudscale-volume-size-gb")
 	d.AntiAffinityWith = flags.String("cloudscale-anti-affinity-with")
+	d.ServerGroups = flags.StringSlice("cloudscale-server-groups")
 
 	d.SetSwarmConfigFromFlags(flags)
 
@@ -194,6 +201,7 @@ func (d *Driver) Create() error {
 		SSHKeys:           []string{string(publicKey)},
 		VolumeSizeGB:      d.VolumeSizeGB,
 		AntiAffinityWith:  d.AntiAffinityWith,
+		ServerGroups:      d.ServerGroups,
 	}
 
 	newServer, err := client.Servers.Create(context.TODO(), createRequest)

--- a/driver.go
+++ b/driver.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	cloudscale "github.com/alakae/cloudscale-go-sdk"
+	cloudscale "github.com/cloudscale-ch/cloudscale-go-sdk"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"

--- a/driver.go
+++ b/driver.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	cloudscale "github.com/cloudscale-ch/cloudscale-go-sdk"
+	cloudscale "github.com/alakae/cloudscale-go-sdk"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/mcnflag"


### PR DESCRIPTION
What's new:
 * Added `--cloudscale-server-groups` option.
 * Build for macOS instead of linux/386.
 * Other small changes and tweaks.